### PR TITLE
Fixing Android version to the newest

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ permalink: /:year/:month/:title/
 paginate: 3
 
 latestiOSRelease : "2.5"
-latestAndroidSDKRelease : "2.2.0"
+latestAndroidSDKRelease : "2.3.3-RAILS"
 
 excerpt_separator: <!--more-->
 highlighter: rouge

--- a/android.md
+++ b/android.md
@@ -23,7 +23,7 @@ This applies to every dependency change from <b>non-RAILS</b> version to <b>-RAI
 <p>For more useful knowledge articles, please visit our&nbsp;<a href="https://support.sensorberg.com/hc/en-us/categories/115000135909-Sensorberg-IoT-Enterprise-Platform" target="_blank">Knowledge Center.</a></p>
 <p>The latest current artifact is:</p>
 {% highlight groovy %}
-compile 'com.sensorberg.sdk:android-sdk:2.3.2-RAILS'
+compile 'com.sensorberg.sdk:{{ site.latestAndroidSDKRelease }}'
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
SDK v2.3.3-RAILS is avalaiable but the there is inconsistency on the integration document